### PR TITLE
Override default site URL in config: bird-calls.com

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ description: >
 author: Alexander Shaw
 email: alexandershaw.f@gmail.com
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "https://yourname.github.io" # the base hostname & protocol for your site
+url: "https://bird-calls.com" # the base hostname & protocol for your site
 collections:
     authors:
         output: true


### PR DESCRIPTION
## Changes

Updates a default config value: use the deployed site URL.

## Motivation

https://bird-calls.com/feed.xml has invalid links to e.g. `https://yourname.github.io/2023/05/bashful`.

## Testing

Rebuild the site locally; confirmed the generated URLs are valid.

```console
$ bundle exec jekyll build
$ head -10 _site/feed.xml
<?xml version="1.0" encoding="UTF-8"?>
<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
  <channel>
    <title>Bird Calls</title>
    <description>Bird Calls
</description>
    <link>https://bird-calls.com/</link>
    <atom:link href="https://bird-calls.com/feed.xml" rel="self" type="application/rss+xml"/>
    <pubDate>Thu, 08 Jun 2023 11:41:03 -0700</pubDate>
    <lastBuildDate>Thu, 08 Jun 2023 11:41:03 -0700</lastBuildDate>
```

This shouldn't have side-effects; the `site.url` variable isn't widely-used.